### PR TITLE
feat: implement info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv/
 *.so
 *.pyc
 .pdm-python
+.idea

--- a/opendalfs/fs.py
+++ b/opendalfs/fs.py
@@ -40,7 +40,7 @@ class OpendalFileSystem(AbstractFileSystem):
         return self.fs.ls(path, **kwargs)
 
     def info(self, path, **kwargs):
-        raise NotImplementedError
+        return self.fs.info(path, **kwargs)
 
     def rm_file(self, path):
         raise NotImplementedError

--- a/tests/test_opendalfs.py
+++ b/tests/test_opendalfs.py
@@ -1,6 +1,7 @@
 import pytest
-from opendalfs import OpendalFileSystem
 from fsspec import AbstractFileSystem
+
+from opendalfs import OpendalFileSystem
 
 
 def test_memory_fs():
@@ -63,3 +64,11 @@ def test_rmdir(opendal_fs):
     assert opendal_fs.ls("/test/") == ["test/another/"]
     opendal_fs.rmdir("/test/another/", recursive=True)
     assert opendal_fs.ls("/test/") == []
+
+
+def test_info(opendal_fs):
+    result = opendal_fs.info("/")
+    assert result == {"name": "/tmp/", "size": 0, "type": "directory"}
+
+    with pytest.raises(FileNotFoundError):
+        opendal_fs.info("/test_file")


### PR DESCRIPTION
Implement `info` according to the [definition](https://github.com/fsspec/filesystem_spec/blob/master/fsspec/spec.py#L657) of return value in `fsspec`. It will return a `dict` with the `name`, `size`, and `type` fields.