### PR TITLE
feat: register URL Protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,32 @@
 
 `opendalfs` is a Python-based interface for file systems that enables interaction with different storage services by [Apache OpenDAL](https://github.com/apache/opendal). Through `opendalfs`, users can utilize fsspec's standard API to operate on all [storage services supported by OpenDAL](https://docs.rs/opendal/latest/opendal/services/index.html).
 
+## URL Protocols
+
+`opendalfs` registers multiple fsspec protocols in the form of `opendal+<service>`, for example:
+
+```python
+import fsspec
+
+f = fsspec.open(
+    "opendal+s3://my-bucket/path/to/file",
+    mode="rb",
+    endpoint="http://localhost:9000",
+    access_key_id="minioadmin",
+    secret_access_key="minioadmin",
+)
+```
+
+The URL host is mapped to the service container (e.g. `bucket` for `s3`/`gcs`, `container` for `azblob`), and the URL path is used as the object key.
+
+For other OpenDAL services, register protocols at runtime:
+
+```python
+import opendalfs
+
+opendalfs.register_opendal_service("oss")
+```
+
 ## Installation
 
 ### Basic Installation

--- a/opendalfs/__init__.py
+++ b/opendalfs/__init__.py
@@ -1,3 +1,8 @@
 from .fs import OpendalFileSystem
+from .registry import register_opendal_protocols, register_opendal_service
 
-__all__ = ["OpendalFileSystem"]
+__all__ = [
+    "OpendalFileSystem",
+    "register_opendal_protocols",
+    "register_opendal_service",
+]

--- a/opendalfs/registry.py
+++ b/opendalfs/registry.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from typing import Any, ClassVar
+from urllib.parse import parse_qsl, urlsplit
+
+from .fs import OpendalFileSystem
+
+
+_DEFAULT_CONTAINER_KEY_BY_SERVICE: dict[str, str] = {
+    "azblob": "container",
+}
+
+_DYNAMIC_FILESYSTEMS: dict[str, type[_OpendalServiceFileSystem]] = {}
+
+
+def _parse_opendal_url(url: str) -> tuple[str | None, str | None, str, dict[str, str]]:
+    if "://" not in url:
+        return None, None, url.lstrip("/"), {}
+
+    parsed = urlsplit(url)
+    scheme = parsed.scheme or None
+    host = parsed.hostname or parsed.netloc or None
+    path = (parsed.path or "").lstrip("/")
+    query = {k: v for k, v in parse_qsl(parsed.query, keep_blank_values=True)}
+    return scheme, host, path, query
+
+
+class _OpendalServiceFileSystem(OpendalFileSystem):
+    protocol: ClassVar[str]
+    service: ClassVar[str]
+    container_key: ClassVar[str] = "bucket"
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs.pop("scheme", None)
+        super().__init__(type(self).service, *args, **kwargs)
+
+    @classmethod
+    def _strip_protocol(cls, path: Any) -> Any:
+        if isinstance(path, (list, tuple)):
+            return type(path)(cls._strip_protocol(p) for p in path)
+        if not isinstance(path, str):
+            return path
+
+        scheme, _host, stripped, _query = _parse_opendal_url(path)
+        if scheme is None:
+            return stripped
+        if scheme != cls.protocol:
+            return path
+        return stripped
+
+    @classmethod
+    def _get_kwargs_from_urls(cls, path: str) -> dict[str, Any]:
+        scheme, host, _stripped, query = _parse_opendal_url(path)
+        if scheme is not None and scheme != cls.protocol:
+            return {}
+
+        kwargs: dict[str, Any] = dict(query)
+        if host:
+            kwargs.setdefault(cls.container_key, host)
+        return kwargs
+
+
+class OpendalS3FileSystem(_OpendalServiceFileSystem):
+    protocol = "opendal+s3"
+    service = "s3"
+    container_key = "bucket"
+
+
+class OpendalGCSFileSystem(_OpendalServiceFileSystem):
+    protocol = "opendal+gcs"
+    service = "gcs"
+    container_key = "bucket"
+
+
+class OpendalAzBlobFileSystem(_OpendalServiceFileSystem):
+    protocol = "opendal+azblob"
+    service = "azblob"
+    container_key = "container"
+
+
+def register_opendal_service(service: str, *, container_key: str | None = None) -> str:
+    from fsspec.registry import register_implementation
+
+    protocol = f"opendal+{service}"
+    if protocol not in _DYNAMIC_FILESYSTEMS:
+        key = container_key or _DEFAULT_CONTAINER_KEY_BY_SERVICE.get(service, "bucket")
+        safe = "".join([c if c.isalnum() else "_" for c in service])
+        name = f"Opendal_{safe}_FileSystem"
+        cls = type(
+            name,
+            (_OpendalServiceFileSystem,),
+            {
+                "protocol": protocol,
+                "service": service,
+                "container_key": key,
+            },
+        )
+        _DYNAMIC_FILESYSTEMS[protocol] = cls
+
+    register_implementation(protocol, _DYNAMIC_FILESYSTEMS[protocol])
+    return protocol
+
+
+def register_opendal_protocols(services: list[str] | None = None) -> list[str]:
+    from fsspec.registry import register_implementation
+
+    builtins: dict[str, type[OpendalFileSystem]] = {
+        "opendal+s3": OpendalS3FileSystem,
+        "opendal+gcs": OpendalGCSFileSystem,
+        "opendal+azblob": OpendalAzBlobFileSystem,
+    }
+
+    if services is None:
+        for protocol, cls in builtins.items():
+            register_implementation(protocol, cls)
+        return sorted(builtins.keys())
+
+    registered: list[str] = []
+    for service in services:
+        protocol = f"opendal+{service}"
+        if protocol in builtins:
+            register_implementation(protocol, builtins[protocol])
+            registered.append(protocol)
+        else:
+            registered.append(register_opendal_service(service))
+
+    return sorted(set(registered))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,11 @@ dependencies = [
     "opendal",
 ]
 
+[project.entry-points."fsspec.specs"]
+"opendal+s3" = "opendalfs.registry:OpendalS3FileSystem"
+"opendal+gcs" = "opendalfs.registry:OpendalGCSFileSystem"
+"opendal+azblob" = "opendalfs.registry:OpendalAzBlobFileSystem"
+
 [project.optional-dependencies]
 # Development dependencies
 dev = [

--- a/tests/core/test_protocol_registration.py
+++ b/tests/core/test_protocol_registration.py
@@ -1,0 +1,47 @@
+from opendalfs.registry import (
+    OpendalAzBlobFileSystem,
+    OpendalGCSFileSystem,
+    OpendalS3FileSystem,
+    register_opendal_protocols,
+    register_opendal_service,
+)
+
+
+def test_register_default_protocols():
+    from fsspec.registry import get_filesystem_class
+
+    registered = register_opendal_protocols()
+    assert registered == ["opendal+azblob", "opendal+gcs", "opendal+s3"]
+
+    assert get_filesystem_class("opendal+s3") is OpendalS3FileSystem
+    assert get_filesystem_class("opendal+gcs") is OpendalGCSFileSystem
+    assert get_filesystem_class("opendal+azblob") is OpendalAzBlobFileSystem
+
+
+def test_strip_protocol_and_kwargs():
+    assert (
+        OpendalS3FileSystem._strip_protocol("opendal+s3://bucket/dir/file.txt")
+        == "dir/file.txt"
+    )
+    assert OpendalS3FileSystem._get_kwargs_from_urls("opendal+s3://bucket/dir/file.txt")[
+        "bucket"
+    ] == "bucket"
+
+    assert (
+        OpendalAzBlobFileSystem._strip_protocol("opendal+azblob://container/dir/file.txt")
+        == "dir/file.txt"
+    )
+    assert OpendalAzBlobFileSystem._get_kwargs_from_urls(
+        "opendal+azblob://container/dir/file.txt"
+    )["container"] == "container"
+
+
+def test_dynamic_service_registration():
+    from fsspec.registry import get_filesystem_class
+
+    protocol = register_opendal_service("oss")
+    assert protocol == "opendal+oss"
+
+    cls = get_filesystem_class("opendal+oss")
+    assert cls.protocol == "opendal+oss"
+    assert cls.service == "oss"


### PR DESCRIPTION
This PR will register URL Protocols

Allow users to use:

```py
import fsspec

f = fsspec.open(
    "opendal+s3://my-bucket/path/to/file",
    mode="rb",
    endpoint="http://localhost:9000",
    access_key_id="minioadmin",
    secret_access_key="minioadmin",
)
```

---

**Parts of this PR were drafted with assistance from Codex (with `gpt-5.2`) and fully reviewed and edited by me. I take full responsibility for all changes.**